### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -7,3 +7,4 @@ Dependency | Sources | Version | Mismatched versions
 [mvutapla-cs/aspnet-app](https://github.com/mvutapla-cs/aspnet-app.git) |  | []() | 
 [mvutapla-cs/cortex-certifai-jx](https://github.com/mvutapla-cs/cortex-certifai-jx.git) |  | []() | 
 [mvutapla-cs/jx-cortex-certifai](https://github.com/mvutapla-cs/jx-cortex-certifai.git) |  | []() | 
+[mvutapla-cs/cortex-docs](https://github.com/mvutapla-cs/cortex-docs.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -29,3 +29,9 @@ dependencies:
   url: https://github.com/mvutapla-cs/jx-cortex-certifai.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: mvutapla-cs
+  repo: cortex-docs
+  url: https://github.com/mvutapla-cs/cortex-docs.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/mvutapla-cs-cortex-certifai-jx-sr.yaml
+++ b/repositories/templates/mvutapla-cs-cortex-certifai-jx-sr.yaml
@@ -2,12 +2,9 @@ apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
   annotations:
-    jenkins.io/last-build-number-for-master: "12"
+    jenkins.io/last-build-number-for-master: "3"
   creationTimestamp: null
   labels:
-    jenkins.io/chart-release: repos
-    jenkins.io/namespace: jx
-    jenkins.io/version: "15"
     owner: mvutapla-cs
     provider: github
     repository: cortex-certifai-jx

--- a/repositories/templates/mvutapla-cs-cortex-docs-sr.yaml
+++ b/repositories/templates/mvutapla-cs-cortex-docs-sr.yaml
@@ -1,6 +1,8 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "2"
   creationTimestamp: null
   labels:
     owner: mvutapla-cs

--- a/repositories/templates/mvutapla-cs-cortex-docs-sr.yaml
+++ b/repositories/templates/mvutapla-cs-cortex-docs-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: mvutapla-cs
+    provider: github
+    repository: cortex-docs
+  name: mvutapla-cs-cortex-docs
+spec:
+  description: Imported application for mvutapla-cs/cortex-docs
+  httpCloneURL: https://github.com/mvutapla-cs/cortex-docs.git
+  org: mvutapla-cs
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: cortex-docs
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/mvutapla-cs/cortex-docs.git


### PR DESCRIPTION
Update [mvutapla-cs/cortex-docs](https://github.com/mvutapla-cs/cortex-docs.git) 

Command run was `jx import`
<hr />

Update [mvutapla-cs/cortex-docs](https://github.com/mvutapla-cs/cortex-docs.git) 

Command run was `jx import`
<hr />

Update [mvutapla-cs/cortex-certifai-jx](https://github.com/mvutapla-cs/cortex-certifai-jx.git) 

Command run was `jx import`