### PR TITLE
chore(deps): bump https://github.com/CognitiveScale/certifai-reference-models-jx.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -11,3 +11,4 @@ Dependency | Sources | Version | Mismatched versions
 [mvutapla-cs/jx-cortex-certifai-docs](https://github.com/mvutapla-cs/jx-cortex-certifai-docs.git) |  | []() | 
 [mvutapla-cs/certifai-docs](https://github.com/mvutapla-cs/certifai-docs.git) |  | []() | 
 [mvutapla-cs/cdocs](https://github.com/mvutapla-cs/cdocs.git) |  | []() | 
+[CognitiveScale/certifai-reference-models-jx](https://github.com/CognitiveScale/certifai-reference-models-jx.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -53,3 +53,9 @@ dependencies:
   url: https://github.com/mvutapla-cs/cdocs.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: CognitiveScale
+  repo: certifai-reference-models-jx
+  url: https://github.com/CognitiveScale/certifai-reference-models-jx.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/cognitivescale-certifai-reference-models-jx-sr.yaml
+++ b/repositories/templates/cognitivescale-certifai-reference-models-jx-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: CognitiveScale
+    provider: github
+    repository: certifai-reference-models-jx
+  name: cognitivescale-certifai-reference-models-jx
+spec:
+  description: Imported application for CognitiveScale/certifai-reference-models-jx
+  httpCloneURL: https://github.com/CognitiveScale/certifai-reference-models-jx.git
+  org: CognitiveScale
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: certifai-reference-models-jx
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/CognitiveScale/certifai-reference-models-jx.git


### PR DESCRIPTION
Update [CognitiveScale/certifai-reference-models-jx](https://github.com/CognitiveScale/certifai-reference-models-jx.git) 

Command run was `jx import`