### PR TITLE
chore(deps): bump https://github.com/CognitiveScale/certifai-reference-models-jx.git 

### DIFF
--- a/repositories/templates/cognitivescale-certifai-reference-models-jx-sr.yaml
+++ b/repositories/templates/cognitivescale-certifai-reference-models-jx-sr.yaml
@@ -1,8 +1,13 @@
 apiVersion: jenkins.io/v1
 kind: SourceRepository
 metadata:
+  annotations:
+    jenkins.io/last-build-number-for-master: "2"
   creationTimestamp: null
   labels:
+    jenkins.io/chart-release: repos
+    jenkins.io/namespace: jx
+    jenkins.io/version: "50"
     owner: CognitiveScale
     provider: github
     repository: certifai-reference-models-jx


### PR DESCRIPTION
Update [CognitiveScale/certifai-reference-models-jx](https://github.com/CognitiveScale/certifai-reference-models-jx.git) 

Command run was `jx import`