### PR TITLE
chore(deps): bump https://github.com/CognitiveScale/certifai-reference-models-jx.git 

### DIFF
--- a/repositories/templates/cognitivescale-certifai-reference-models-jx-sr.yaml
+++ b/repositories/templates/cognitivescale-certifai-reference-models-jx-sr.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     jenkins.io/chart-release: repos
     jenkins.io/namespace: jx
-    jenkins.io/version: "50"
+    jenkins.io/version: "51"
     owner: CognitiveScale
     provider: github
     repository: certifai-reference-models-jx


### PR DESCRIPTION
Update [CognitiveScale/certifai-reference-models-jx](https://github.com/CognitiveScale/certifai-reference-models-jx.git) 

Command run was `jx import`